### PR TITLE
Use coveralls for coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
-python: 3.5
+python:
+  - 2.7
+  - 3.5
 install:
   - pip install tox
-script: tox
-env:
-  - TOXENV=py27
-  - TOXENV=py34
-  - TOXENV=pep8
+  - pip install coveralls
+script:
+  - tox -e py$(echo $TRAVIS_PYTHON_VERSION | tr -d .)
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # flask-test
 [![Build Status](https://travis-ci.org/eduardobmc/flask-test.svg?branch=master)](https://travis-ci.org/eduardobmc/flask-test)
+[![Coverage Status](https://coveralls.io/repos/github/eduardobmc/flask-test/badge.svg?branch=master)](https://coveralls.io/github/eduardobmc/flask-test)
 
 Simple python flask application

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = py27,py35,pep8
+envlist = py{27,35}
 
 [testenv]
 deps = pytest
        coverage
-commands = coverage erase
+       flake8
+commands = flake8 .
            coverage run --branch --omit='{toxworkdir}/*' -m pytest tests {posargs}
            coverage report --fail-under=100
            coverage html -d htmlcov-{envname}
-
-[testenv:pep8]
-deps = flake8
-commands = flake8 mymodule tests


### PR DESCRIPTION
Change `tox.ini` to publish coverage information to coveralls.