### PR TITLE
Exclude tests directory from code climate checks.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,3 +14,5 @@ engines:
 ratings:
   paths:
   - "**.py"
+exclude_paths:
+  - "tests/"


### PR DESCRIPTION
The code duplication alerts for test code are not helpful. This PR disables checks for the `tests/` directory.