### PR TITLE
Support for unquoted boundary strings.

### DIFF
--- a/mymodule/blueprints/api_v1/upload.py
+++ b/mymodule/blueprints/api_v1/upload.py
@@ -77,7 +77,7 @@ def get_io_stream(stream):
 
 
 def get_boundary(content_type):
-    r = re.compile(r'boundary="(?P<boundary>.*)"')
+    r = re.compile('boundary="?(?P<boundary>[^"]*)"?')
     m = r.search(content_type)
     boundary = '--' + m.group('boundary')
     return bytearray(boundary, 'ascii')

--- a/mymodule/utils.py
+++ b/mymodule/utils.py
@@ -1,4 +1,5 @@
 import re
+import six
 
 
 CRLF = b'\r\n'
@@ -20,7 +21,11 @@ def read_headers(reader):
     headers = {
       k: v for k, v in directives(content_disposition)
     }
-    headers['content-type'] = raw_headers['content-type']
+    headers.update({
+      k.lower(): v
+      for k, v in six.iteritems(raw_headers)
+      if k.lower() != 'content-disposition'
+    })
     return headers
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
   version='1.0',
   packages=find_packages(exclude=['tests']),
   install_requires=[
-    'flask==0.11'
+    'flask==0.11',
+    'six'
   ],
 )


### PR DESCRIPTION
Some clients do not send quoted boundary strings. Add support for them.