### PR TITLE
Use werkzeug utils for header parsing

### DIFF
--- a/mymodule/blueprints/api_v1/upload.py
+++ b/mymodule/blueprints/api_v1/upload.py
@@ -1,8 +1,8 @@
 import io
-import re
 import hashlib
 import flask
 from flask import current_app as app
+from werkzeug import http
 
 from ... import utils
 
@@ -77,7 +77,5 @@ def get_io_stream(stream):
 
 
 def get_boundary(content_type):
-    r = re.compile('boundary="?(?P<boundary>[^"]*)"?')
-    m = r.search(content_type)
-    boundary = '--' + m.group('boundary')
-    return bytearray(boundary, 'ascii')
+    value, options = http.parse_options_header(content_type)
+    return b'--' + options['boundary'].encode('ascii')

--- a/mymodule/utils.py
+++ b/mymodule/utils.py
@@ -33,7 +33,6 @@ def options(value):
 def read_until_part(reader):
     delim = CRLF * 2
     data = read_until(reader, delim)
-    # reader.read(len(delim))
     return data
 
 

--- a/mymodule/utils.py
+++ b/mymodule/utils.py
@@ -1,5 +1,6 @@
-import re
+import six
 from six import moves
+from werkzeug import http
 
 
 CRLF = b'\r\n'
@@ -17,17 +18,16 @@ def read_headers(reader):
         name, value = line.decode('ascii').split(': ')
         name = name.lower()
         if name == 'content-disposition':
-            for k, v in directives(value):
+            for k, v in options(value):
                 headers[k] = v
         else:
             headers[name] = value
     return headers
 
 
-def directives(value):
-    r = re.compile(r';\s*([^=]+)="([^"]+)"')
-    for m in r.finditer(value):
-        yield m.group(1), m.group(2)
+def options(value):
+    _, options = http.parse_options_header(value)
+    return six.iteritems(options)
 
 
 def read_until_part(reader):

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,6 @@ deps = pytest
        flake8
 commands = flake8 .
            coverage erase
-           coverage run --branch --omit='{toxworkdir}/*' -m pytest tests {posargs}
+           coverage run --branch --omit='{toxworkdir}/*' -m pytest {posargs:tests}
            coverage html -d htmlcov-{envname}
            coverage report --fail-under=100


### PR DESCRIPTION
Instead of regular expressions, use `werkzeug.http.parse_options_header` for parsing headers.