### PR TITLE
Add skip option for read_until() and yield_until()

### DIFF
--- a/mymodule/utils.py
+++ b/mymodule/utils.py
@@ -43,10 +43,9 @@ def parse_multipart(reader, boundary):
         headers = read_headers(reader)
         reader.read(2 * len(CRLF))
 
-        part = yield_until(reader, CRLF + boundary)
+        part = yield_until(reader, CRLF + boundary, skip=True)
         yield headers, part
 
-        reader.read(len(CRLF + boundary))
         end = reader.peek()
         if len(end) == 0 or end == b'--' + CRLF:
             break

--- a/mymodule/utils.py
+++ b/mymodule/utils.py
@@ -52,7 +52,7 @@ def parse_multipart(reader, boundary):
             break
 
 
-def yield_until(reader, delim, size=65536):
+def yield_until(reader, delim, size=65536, skip=False):
     for chunk in iter(lambda: _peek(reader, 2 * size), b''):
         index = chunk.find(delim)
         if index == -1:
@@ -63,7 +63,7 @@ def yield_until(reader, delim, size=65536):
             yield chunk[:min(index, size)]
             if size < index:
                 yield chunk[size:index]
-            reader.read(index)
+            reader.read(index + len(delim) if skip else index)
             break
 
 

--- a/mymodule/utils.py
+++ b/mymodule/utils.py
@@ -6,8 +6,8 @@ from werkzeug import http
 CRLF = b'\r\n'
 
 
-def read_until(reader, delim):
-    chunks = yield_until(reader, delim)
+def read_until(reader, delim, skip=False):
+    chunks = yield_until(reader, delim, skip=skip)
     return b''.join(chunks)
 
 

--- a/mymodule/utils.py
+++ b/mymodule/utils.py
@@ -31,18 +31,15 @@ def options(value):
 
 def read_until_part(reader):
     delim = CRLF * 2
-    data = read_until(reader, delim)
+    data = read_until(reader, delim, skip=True)
     return data
 
 
 def parse_multipart(reader, boundary):
-    read_until(reader, boundary)
-    reader.read(len(boundary))
+    read_until(reader, boundary, skip=True)
 
     while True:
         headers = read_headers(reader)
-        reader.read(2 * len(CRLF))
-
         part = yield_until(reader, CRLF + boundary, skip=True)
         yield headers, part
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,4 @@
 import io
-import pytest
 import unittest
 
 from mymodule import utils
@@ -11,7 +10,6 @@ class YieldUntilTest(unittest.TestCase):
         stream = io.BytesIO(content)
         self.reader = io.BufferedReader(stream)
 
-    @pytest.mark.parse
     def test_yield_until(self):
         iterator = utils.yield_until(self.reader, b'6|7', size=4)
         self.assertEquals(next(iterator), b'012|')
@@ -19,7 +17,6 @@ class YieldUntilTest(unittest.TestCase):
         self.assertRaises(StopIteration, next, iterator)
         self.assertEquals(self.reader.read(), b'6|789|ab')
 
-    @pytest.mark.parse
     def test_yield_size(self):
         iterator = utils.yield_until(self.reader, b'9|a', size=4)
         self.assertEquals(next(iterator), b'012|')
@@ -28,7 +25,6 @@ class YieldUntilTest(unittest.TestCase):
         self.assertRaises(StopIteration, next, iterator)
         self.assertEquals(self.reader.read(), b'9|ab')
 
-    @pytest.mark.parse
     def test_yield_upper_half(self):
         iterator = utils.yield_until(self.reader, b'56', size=4)
         self.assertEquals(next(iterator), b'012|')
@@ -36,7 +32,6 @@ class YieldUntilTest(unittest.TestCase):
         self.assertRaises(StopIteration, next, iterator)
         self.assertEquals(self.reader.read(), b'56|789|ab')
 
-    @pytest.mark.parse
     def test_yield_not_found(self):
         iterator = utils.yield_until(self.reader, b'xyz', size=4)
         self.assertEquals(next(iterator), b'012|')
@@ -44,6 +39,14 @@ class YieldUntilTest(unittest.TestCase):
         self.assertEquals(next(iterator), b'789|')
         self.assertEquals(next(iterator), b'ab')
         self.assertRaises(StopIteration, next, iterator)
+
+    def test_skip(self):
+        iterator = utils.yield_until(self.reader, b'9|', size=4, skip=True)
+        self.assertEquals(next(iterator), b'012|')
+        self.assertEquals(next(iterator), b'456|')
+        self.assertEquals(next(iterator), b'78')
+        self.assertRaises(StopIteration, next, iterator)
+        self.assertEquals(self.reader.read(), b'ab')
 
 
 class ReadUntilTest(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -63,6 +63,11 @@ class ReadUntilTest(unittest.TestCase):
         self.assertEquals(utils.read_until(self.reader, b'xyz'), b'abcdefgh')
         self.assertEquals(self.reader.read(), b'')
 
+    def test_skip(self):
+        data = utils.read_until(self.reader, b'efg', skip=True)
+        self.assertEquals(data, b'abcd')
+        self.assertEquals(self.reader.read(), b'h')
+
 
 class ParserTest(unittest.TestCase):
     def test_headers(self):


### PR DESCRIPTION
New option will skip the delimiter, if found.